### PR TITLE
v0.1.1: Edition 2024, metadata, auto-publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,47 @@
+name: Publish to crates.io
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "Cargo.toml"
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Check if version changed
+        id: version
+        run: |
+          NEW_VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')
+          git show HEAD~1:Cargo.toml > /tmp/old_cargo.toml 2>/dev/null || true
+          OLD_VERSION=$(grep -m1 '^version' /tmp/old_cargo.toml | sed 's/.*"\(.*\)"/\1/' || echo "")
+          echo "old=$OLD_VERSION" >> "$GITHUB_OUTPUT"
+          echo "new=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+          if [ "$NEW_VERSION" != "$OLD_VERSION" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build
+        if: steps.version.outputs.changed == 'true'
+        run: cargo build --verbose
+
+      - name: Run tests
+        if: steps.version.outputs.changed == 'true'
+        run: cargo test --verbose
+
+      - name: Publish to crates.io
+        if: steps.version.outputs.changed == 'true'
+        run: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## [0.1.1] - 2026-03-15
+
+### Changed
+- Bumped Rust edition from 2021 to 2024 (MSRV 1.85)
+- Switched license field to SPDX identifier
+- Added crates.io metadata (keywords, categories, homepage, rust-version)
+
+### Added
+- GitHub Actions workflow for automatic crates.io publishing on version bump
+- Log generation test script (`scripts/gen_logs.sh`)
+
 ## [0.1.0] - 2024-11-18
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,21 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project
+
+ttail is a Rust CLI tool that buffers terminal output, displaying the last N lines of stdin in a scrolling fashion using ANSI escape codes. No external dependencies — pure Rust std lib.
+
+## Build Commands
+
+- **Build:** `cargo build --verbose`
+- **Test:** `cargo test --verbose`
+- **Run:** `echo "some\nlines" | cargo run`
+
+CI runs on Ubuntu via GitHub Actions (`.github/workflows/rust.yml`) on push/PR to main.
+
+## Architecture
+
+Single-file program in `src/main.rs` with two functions:
+- `clear_lines(num_lines)` — uses ANSI escape sequences (`\x1B[1A`, `\x1B[2K`) to clear and redraw terminal lines
+- `main()` — reads stdin line-by-line, maintains a rolling buffer of the last 10 lines, clears previous display and reprints on each new line, stops on empty input

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,13 @@
 [package]
 name = "ttail"
-version = "0.1.0"
-edition = "2021"
+version = "0.1.1"
+edition = "2024"
 authors = ["Dmitri Tchebotarev <dmitri@tchebotarev.com>"]
-license-file = "LICENSE"
+license = "MIT"
 description = "Small program to display last N lines of output."
 repository = "https://github.com/DTchebotarev/ttail"
+homepage = "https://github.com/DTchebotarev/ttail"
 readme = "README.md"
+keywords = ["terminal", "tail", "log", "cli", "buffer"]
+categories = ["command-line-utilities"]
+rust-version = "1.85"

--- a/scripts/gen_logs.sh
+++ b/scripts/gen_logs.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Generates 1000 lines of randomish log output to stdout.
+# Usage: ./scripts/gen_logs.sh | cargo run
+
+set -euo pipefail
+
+LEVELS=("INFO" "WARN" "ERROR" "DEBUG" "TRACE")
+COMPONENTS=("api" "db" "auth" "cache" "scheduler" "worker" "gateway" "metrics")
+MESSAGES=(
+  "request completed successfully"
+  "connection timed out"
+  "retrying operation"
+  "cache miss for key"
+  "user session expired"
+  "health check passed"
+  "failed to parse payload"
+  "rate limit exceeded"
+  "query executed"
+  "spawning background task"
+  "TLS handshake complete"
+  "disk usage above threshold"
+  "config reloaded"
+  "upstream returned 503"
+  "record not found"
+)
+
+timestamp() {
+  if date --version >/dev/null 2>&1; then
+    # GNU date
+    date -d "+${1} seconds" '+%Y-%m-%dT%H:%M:%S'
+  else
+    # macOS date
+    date -v+"${1}"S '+%Y-%m-%dT%H:%M:%S'
+  fi
+}
+
+for i in $(seq 1 1000); do
+  ts=$(timestamp "$i")
+  level=${LEVELS[$((RANDOM % ${#LEVELS[@]}))]}
+  comp=${COMPONENTS[$((RANDOM % ${#COMPONENTS[@]}))]}
+  msg=${MESSAGES[$((RANDOM % ${#MESSAGES[@]}))]}
+  rid=$((RANDOM % 90000 + 10000))
+  printf '%s [%-5s] %s: %s (rid=%d)\n' "$ts" "$level" "$comp" "$msg" "$rid"
+done


### PR DESCRIPTION
## Summary
- Bump Rust edition from 2021 to 2024 (MSRV 1.85)
- Fix license to SPDX identifier, add crates.io metadata (keywords, categories, homepage, rust-version)
- Add GitHub Actions workflow to auto-publish to crates.io on version bump
- Add test log generator script and CLAUDE.md

## Test plan
- [x] Verify `cargo build` succeeds
- [x] Verify `scripts/gen_logs.sh | cargo run` works
- [ ] Merge and confirm publish workflow triggers on crates.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)