### PR TITLE
Bump actions/checkout v4 → v5

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
     if: github.event.workflow_run.conclusion == 'success'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Check if version is new
         id: version

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,6 +15,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Build and test
       run: ./scripts/ci/build.sh


### PR DESCRIPTION
## Summary
- Bump actions/checkout from v4 to v5 in both workflows
- Fixes Node.js 20 deprecation warning (forced to Node.js 24 starting June 2, 2026)

🤖 Generated with [Claude Code](https://claude.com/claude-code)