### PR TITLE
Preserve ANSI colors across buffer eviction

### DIFF
--- a/.claude/skills/version-bump/SKILL.md
+++ b/.claude/skills/version-bump/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: version-bump
+description: Bump the project version (major/minor/patch) across all relevant files
+disable-model-invocation: true
+argument-hint: "[major|minor|patch]"
+---
+
+Bump the project version. If an argument is provided ($ARGUMENTS), use it directly. Otherwise, analyze recent changes and suggest major/minor/patch with reasoning, then ask the user which to apply.
+
+## Versioning guidelines
+
+Use semver (https://semver.org):
+- **patch**: Bug fixes, documentation, CI changes, refactoring with no API changes
+- **minor**: New features, new public API surface, backwards-compatible changes
+- **major**: Breaking changes to public API or behavior
+
+## Steps
+
+1. Read `Cargo.toml` to get the current version
+2. Read `CHANGELOG.md` to understand what's changed since the last release
+3. Check recent git history since the last version tag: !`git log --oneline $(git describe --tags --abbrev=0 2>/dev/null || echo HEAD~20)..HEAD 2>/dev/null || git log --oneline -20`
+4. If no argument was provided, suggest all three options with the resulting version number and reasoning for each, then ask the user to pick one
+5. Compute the new version number
+6. Update ALL of these files:
+   - `Cargo.toml` — the `version` field
+   - `Cargo.lock` — run `cargo generate-lockfile` to sync it
+   - `CHANGELOG.md` — add a new section header with the new version and today's date, moving any unreleased notes under it
+7. Verify with `cargo build --locked` that the lockfile is in sync
+8. Show the user a summary of what was changed and the new version number

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+## [0.2.0] - 2026-03-15
+
+### Added
+- ANSI color preservation across buffer eviction (basic, 256-color, and RGB)
+- `LineBuffer` public API with `AnsiState` tracking
+- Performance benchmark suite (`cargo bench`)
+- Colored log test script for visual ANSI verification
+- Unit tests for ANSI state tracking (17 total)
+- `/version-bump` skill for semver version management
+
+### Changed
+- Extracted core logic into `src/lib.rs` for testability
+- Switched internal buffer from `Vec` to `VecDeque` for O(1) eviction
+- Reset ANSI state before clearing lines to prevent background color bleed
+- Updated README with install/usage/development instructions
+
+### Fixed
+- Background colors filling cleared lines via `\x1B[2K]`
+- Extended color output missing `38;`/`48;` prefix for palette and RGB
+- Stale `Cargo.lock` causing publish failures
+
 ## [0.1.1] - 2026-03-15
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 4
 
 [[package]]
 name = "ttail"
-version = "0.1.1"
+version = "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ttail"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2024"
 authors = ["Dmitri Tchebotarev <dmitri@tchebotarev.com>"]
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,7 @@ readme = "README.md"
 keywords = ["terminal", "tail", "log", "cli", "buffer"]
 categories = ["command-line-utilities"]
 rust-version = "1.85"
+
+[[bench]]
+name = "line_buffer"
+harness = false

--- a/README.md
+++ b/README.md
@@ -1,1 +1,34 @@
-A small program for buffering terminal output. WIP.
+# ttail
+
+A small, zero-dependency Rust CLI that displays the last N lines of stdin in a rolling window using ANSI escape codes. Think `tail -f`, but for piped output that overwrites itself in place.
+
+ANSI color codes are preserved — even when the line that set the color has scrolled out of the buffer.
+
+## Install
+
+```sh
+cargo install ttail
+```
+
+## Usage
+
+```sh
+# Pipe any command into ttail
+my-noisy-command | ttail
+
+# Great for watching logs, builds, test output, etc.
+cargo test 2>&1 | ttail
+```
+
+## Development
+
+```sh
+cargo build --verbose
+cargo test --verbose
+
+# Generate sample log data
+./scripts/dev/gen_logs.sh | cargo run
+
+# Run performance benchmarks
+./scripts/dev/bench.sh
+```

--- a/benches/line_buffer.rs
+++ b/benches/line_buffer.rs
@@ -1,0 +1,81 @@
+use std::time::Instant;
+use ttail::{LineBuffer, AnsiState, update_ansi_state};
+
+fn bench<F: FnMut()>(name: &str, iterations: u32, mut f: F) {
+    // Warmup
+    for _ in 0..iterations / 10 {
+        f();
+    }
+
+    let start = Instant::now();
+    for _ in 0..iterations {
+        f();
+    }
+    let elapsed = start.elapsed();
+    let per_iter = elapsed / iterations;
+    println!("{name}: {per_iter:?}/iter ({iterations} iterations, {elapsed:?} total)");
+}
+
+fn main() {
+    let iterations = 10_000;
+
+    bench("push_plain_lines_1k", iterations, || {
+        let mut buf = LineBuffer::new(10);
+        for i in 0..1000 {
+            buf.push(format!("2026-03-15T12:00:{i:02} [INFO] worker: request completed (rid={i})"));
+        }
+    });
+
+    bench("push_colored_lines_1k", iterations, || {
+        let mut buf = LineBuffer::new(10);
+        for i in 0..1000 {
+            buf.push(format!("\x1B[1;31m2026-03-15T12:00:{i:02}\x1B[0m \x1B[32m[INFO]\x1B[0m worker: request completed"));
+        }
+    });
+
+    bench("display_lines_plain", iterations, || {
+        let mut buf = LineBuffer::new(10);
+        for i in 0..100 {
+            buf.push(format!("line {i}"));
+        }
+        std::hint::black_box(buf.display_lines());
+    });
+
+    bench("display_lines_with_ansi_prefix", iterations, || {
+        let mut buf = LineBuffer::new(10);
+        buf.push("\x1B[1;31;44mbold red on blue".to_string());
+        for i in 0..100 {
+            buf.push(format!("line {i}"));
+        }
+        std::hint::black_box(buf.display_lines());
+    });
+
+    bench("ansi_state_parse_simple", iterations * 10, || {
+        let mut state = AnsiState::default();
+        update_ansi_state(&mut state, "\x1B[31mhello world");
+        std::hint::black_box(&state);
+    });
+
+    bench("ansi_state_parse_complex", iterations * 10, || {
+        let mut state = AnsiState::default();
+        update_ansi_state(&mut state, "\x1B[1;38;5;208m\x1B[48;2;10;20;30mcomplex colors\x1B[0m\x1B[32mgreen");
+        std::hint::black_box(&state);
+    });
+
+    bench("push_and_display_realistic", iterations, || {
+        let mut buf = LineBuffer::new(10);
+        let lines = [
+            "\x1B[90m2026-03-15T12:00:01\x1B[0m \x1B[32m[INFO ]\x1B[0m api: request completed (rid=12345)",
+            "\x1B[90m2026-03-15T12:00:02\x1B[0m \x1B[33m[WARN ]\x1B[0m cache: miss for key user:99",
+            "\x1B[90m2026-03-15T12:00:03\x1B[0m \x1B[31m[ERROR]\x1B[0m db: connection timed out",
+            "\x1B[90m2026-03-15T12:00:04\x1B[0m \x1B[34m[DEBUG]\x1B[0m auth: session validated",
+            "\x1B[90m2026-03-15T12:00:05\x1B[0m \x1B[32m[INFO ]\x1B[0m worker: task spawned",
+        ];
+        for _ in 0..200 {
+            for line in &lines {
+                buf.push(line.to_string());
+                std::hint::black_box(buf.display_lines());
+            }
+        }
+    });
+}

--- a/scripts/dev/bench.sh
+++ b/scripts/dev/bench.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Run performance benchmarks for ttail.
+# Usage: ./scripts/dev/bench.sh
+set -euo pipefail
+
+cargo bench --bench line_buffer

--- a/scripts/dev/gen_colored_logs.sh
+++ b/scripts/dev/gen_colored_logs.sh
@@ -30,7 +30,7 @@ DIM='\x1B[2m'
 ITALIC='\x1B[3m'
 UNDERLINE='\x1B[4m'
 
-delay() { sleep 0.05; }
+delay() { sleep 0.15; }
 
 # Phase 1: Bold red, no reset between lines
 printf "${RED}[Phase 1] Bold red starts here\n"; delay

--- a/scripts/dev/gen_colored_logs.sh
+++ b/scripts/dev/gen_colored_logs.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Generates colored log output to test ANSI color preservation in ttail.
+# The color set on line 1 (bold red) should persist even after it scrolls
+# out of the buffer. Watch for color bleeding or loss as lines scroll.
+#
+# Usage: ./scripts/dev/gen_colored_logs.sh | cargo run
+#
+# Expected behavior:
+#   - Lines 1-5: bold red (set explicitly on line 1, no reset)
+#   - Lines 6-10: green (reset then green on line 6)
+#   - Lines 11-15: blue background with white text (set on line 11)
+#   - Lines 16-20: 256-color orange (set on line 16)
+#   - Lines 21-25: RGB purple (set on line 21)
+#   - Lines 26-30: mixed — each line sets its own color
+#   - Lines 31-40: rapid color changes to stress test
+#
+# Since ttail shows 10 lines at a time, by line 12 the originating
+# color line (line 1) has scrolled out. If colors are preserved
+# correctly, lines should still render in the active color.
+set -euo pipefail
+
+RED='\x1B[1;31m'
+GREEN='\x1B[32m'
+BLUE_BG='\x1B[44;37m'
+ORANGE_256='\x1B[38;5;208m'
+PURPLE_RGB='\x1B[38;2;128;0;255m'
+RESET='\x1B[0m'
+BOLD='\x1B[1m'
+DIM='\x1B[2m'
+ITALIC='\x1B[3m'
+UNDERLINE='\x1B[4m'
+
+delay() { sleep 0.05; }
+
+# Phase 1: Bold red, no reset between lines
+printf "${RED}[Phase 1] Bold red starts here\n"; delay
+for i in $(seq 2 5); do
+  printf "  line $i should still be bold red\n"; delay
+done
+
+# Phase 2: Switch to green
+printf "${RESET}${GREEN}[Phase 2] Switched to green\n"; delay
+for i in $(seq 7 10); do
+  printf "  line $i should be green\n"; delay
+done
+
+# Phase 3: Blue background, white text
+printf "${RESET}${BLUE_BG}[Phase 3] Blue bg, white text\n"; delay
+for i in $(seq 12 15); do
+  printf "  line $i should have blue background\n"; delay
+done
+
+# Phase 4: 256-color orange
+printf "${RESET}${ORANGE_256}[Phase 4] 256-color orange\n"; delay
+for i in $(seq 17 20); do
+  printf "  line $i should be orange\n"; delay
+done
+
+# Phase 5: RGB purple
+printf "${RESET}${PURPLE_RGB}[Phase 5] RGB purple\n"; delay
+for i in $(seq 22 25); do
+  printf "  line $i should be purple\n"; delay
+done
+
+# Phase 6: Each line has its own color
+printf "${RESET}${RED}[Phase 6] This line is red\n"; delay
+printf "${GREEN}[Phase 6] This line is green\n"; delay
+printf "${BLUE_BG}[Phase 6] This line has blue bg\n"; delay
+printf "${RESET}${BOLD}[Phase 6] This line is bold\n"; delay
+printf "${RESET}${UNDERLINE}[Phase 6] This line is underlined\n"; delay
+
+# Phase 7: Rapid color changes
+printf "${RESET}\n"
+for i in $(seq 31 40); do
+  code=$((31 + (i % 7)))
+  printf "\x1B[${code}m[Phase 7] Rapid color line $i\n"; delay
+done
+
+# Final reset
+printf "${RESET}"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,387 @@
+use std::collections::VecDeque;
+use std::fmt::Write;
+
+#[derive(Clone, Default, PartialEq, Debug)]
+pub struct AnsiState {
+    reset: bool,
+    bold: bool,
+    dim: bool,
+    italic: bool,
+    underline: bool,
+    blink: bool,
+    reverse: bool,
+    hidden: bool,
+    strikethrough: bool,
+    fg: Option<Color>,
+    bg: Option<Color>,
+}
+
+#[derive(Clone, PartialEq, Debug)]
+pub enum Color {
+    Basic(u8),       // 30-37, 39, 40-47, 49, 90-97, 100-107
+    Palette(u8),     // 38;5;N or 48;5;N
+    Rgb(u8, u8, u8), // 38;2;R;G;B or 48;2;R;G;B
+}
+
+impl AnsiState {
+    fn apply_sgr(&mut self, params: &[u8]) {
+        if params.is_empty() {
+            *self = Self::default();
+            return;
+        }
+        let mut i = 0;
+        while i < params.len() {
+            match params[i] {
+                0 => *self = Self::default(),
+                1 => self.bold = true,
+                2 => self.dim = true,
+                3 => self.italic = true,
+                4 => self.underline = true,
+                5 => self.blink = true,
+                7 => self.reverse = true,
+                8 => self.hidden = true,
+                9 => self.strikethrough = true,
+                22 => { self.bold = false; self.dim = false; }
+                23 => self.italic = false,
+                24 => self.underline = false,
+                25 => self.blink = false,
+                27 => self.reverse = false,
+                28 => self.hidden = false,
+                29 => self.strikethrough = false,
+                n @ 30..=37 => self.fg = Some(Color::Basic(n)),
+                38 => {
+                    if let Some(color) = Self::parse_extended(&params[i..]) {
+                        match color {
+                            Color::Palette(_) => i += 2,
+                            Color::Rgb(_, _, _) => i += 4,
+                            _ => {}
+                        }
+                        self.fg = Some(color);
+                    }
+                }
+                39 => self.fg = None,
+                n @ 40..=47 => self.bg = Some(Color::Basic(n)),
+                48 => {
+                    if let Some(color) = Self::parse_extended(&params[i..]) {
+                        match color {
+                            Color::Palette(_) => i += 2,
+                            Color::Rgb(_, _, _) => i += 4,
+                            _ => {}
+                        }
+                        self.bg = Some(color);
+                    }
+                }
+                49 => self.bg = None,
+                n @ 90..=97 => self.fg = Some(Color::Basic(n)),
+                n @ 100..=107 => self.bg = Some(Color::Basic(n)),
+                _ => {}
+            }
+            i += 1;
+        }
+    }
+
+    fn parse_extended(params: &[u8]) -> Option<Color> {
+        if params.len() >= 3 && params[1] == 5 {
+            Some(Color::Palette(params[2]))
+        } else if params.len() >= 5 && params[1] == 2 {
+            Some(Color::Rgb(params[2], params[3], params[4]))
+        } else {
+            None
+        }
+    }
+
+    pub fn to_escape(&self) -> String {
+        let mut codes: Vec<String> = Vec::new();
+        if self.bold { codes.push("1".into()); }
+        if self.dim { codes.push("2".into()); }
+        if self.italic { codes.push("3".into()); }
+        if self.underline { codes.push("4".into()); }
+        if self.blink { codes.push("5".into()); }
+        if self.reverse { codes.push("7".into()); }
+        if self.hidden { codes.push("8".into()); }
+        if self.strikethrough { codes.push("9".into()); }
+        if let Some(ref c) = self.fg {
+            Self::color_to_codes(c, &mut codes);
+        }
+        if let Some(ref c) = self.bg {
+            Self::color_to_codes(c, &mut codes);
+        }
+        if codes.is_empty() {
+            String::new()
+        } else {
+            let mut out = String::new();
+            write!(out, "\x1B[{}m", codes.join(";")).unwrap();
+            out
+        }
+    }
+
+    fn color_to_codes(color: &Color, codes: &mut Vec<String>) {
+        match color {
+            Color::Basic(n) => codes.push(n.to_string()),
+            Color::Palette(n) => {
+                // Determine if fg (38) or bg (48) from the original code context
+                // Basic codes 30-37/90-97 are fg, 40-47/100-107 are bg
+                // For palette, we need to check if this is stored as fg or bg
+                // This is handled by the caller context, so we just emit the number
+                codes.push(format!("5;{n}"));
+            }
+            Color::Rgb(r, g, b) => {
+                codes.push(format!("2;{r};{g};{b}"));
+            }
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        *self == Self::default()
+    }
+}
+
+fn parse_sgr_params(seq: &str) -> Vec<u8> {
+    if seq.is_empty() {
+        return vec![0];
+    }
+    seq.split(';')
+        .filter_map(|s| s.parse::<u8>().ok())
+        .collect()
+}
+
+pub fn update_ansi_state(state: &mut AnsiState, line: &str) {
+    let bytes = line.as_bytes();
+    let len = bytes.len();
+    let mut i = 0;
+    while i < len {
+        if bytes[i] == 0x1B && i + 1 < len && bytes[i + 1] == b'[' {
+            i += 2;
+            let start = i;
+            while i < len && bytes[i] != b'm' && bytes[i] != b'A' && bytes[i] != b'B'
+                && bytes[i] != b'C' && bytes[i] != b'D' && bytes[i] != b'H'
+                && bytes[i] != b'J' && bytes[i] != b'K'
+            {
+                i += 1;
+            }
+            if i < len && bytes[i] == b'm' {
+                let param_str = &line[start..i];
+                let params = parse_sgr_params(param_str);
+                state.apply_sgr(&params);
+            }
+            i += 1;
+        } else {
+            i += 1;
+        }
+    }
+}
+
+pub struct LineBuffer {
+    lines: VecDeque<String>,
+    capacity: usize,
+    ansi_prefix: AnsiState,
+}
+
+impl LineBuffer {
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            lines: VecDeque::new(),
+            capacity,
+            ansi_prefix: AnsiState::default(),
+        }
+    }
+
+    pub fn push(&mut self, line: String) {
+        self.lines.push_back(line);
+        if self.lines.len() > self.capacity {
+            if let Some(evicted) = self.lines.pop_front() {
+                update_ansi_state(&mut self.ansi_prefix, &evicted);
+            }
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.lines.len()
+    }
+
+    pub fn lines(&self) -> Vec<&str> {
+        self.lines.iter().map(|s| s.as_str()).collect()
+    }
+
+    pub fn display_lines(&self) -> Vec<String> {
+        let lines: Vec<&str> = self.lines.iter().map(|s| s.as_str()).collect();
+        if lines.is_empty() || self.ansi_prefix.is_empty() {
+            return lines.into_iter().map(String::from).collect();
+        }
+        let prefix = self.ansi_prefix.to_escape();
+        let mut result: Vec<String> = Vec::with_capacity(lines.len());
+        result.push(format!("{}{}", prefix, lines[0]));
+        for line in &lines[1..] {
+            result.push((*line).to_string());
+        }
+        result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn buffer_stays_within_capacity() {
+        let mut buf = LineBuffer::new(3);
+        for i in 0..5 {
+            buf.push(format!("line {i}"));
+        }
+        assert_eq!(buf.len(), 3);
+        assert_eq!(buf.lines(), &["line 2", "line 3", "line 4"]);
+    }
+
+    #[test]
+    fn buffer_under_capacity() {
+        let mut buf = LineBuffer::new(10);
+        buf.push("a".to_string());
+        buf.push("b".to_string());
+        assert_eq!(buf.len(), 2);
+        assert_eq!(buf.lines(), &["a", "b"]);
+    }
+
+    #[test]
+    fn buffer_exact_capacity() {
+        let mut buf = LineBuffer::new(3);
+        buf.push("a".to_string());
+        buf.push("b".to_string());
+        buf.push("c".to_string());
+        assert_eq!(buf.len(), 3);
+        assert_eq!(buf.lines(), &["a", "b", "c"]);
+    }
+
+    #[test]
+    fn buffer_drops_oldest() {
+        let mut buf = LineBuffer::new(2);
+        buf.push("first".to_string());
+        buf.push("second".to_string());
+        buf.push("third".to_string());
+        assert_eq!(buf.lines(), &["second", "third"]);
+    }
+
+    #[test]
+    fn buffer_capacity_one() {
+        let mut buf = LineBuffer::new(1);
+        buf.push("a".to_string());
+        buf.push("b".to_string());
+        assert_eq!(buf.len(), 1);
+        assert_eq!(buf.lines(), &["b"]);
+    }
+
+    #[test]
+    fn empty_buffer() {
+        let buf = LineBuffer::new(10);
+        assert_eq!(buf.len(), 0);
+        assert!(buf.lines().is_empty());
+    }
+
+    // ANSI state tracking tests
+
+    #[test]
+    fn no_ansi_no_prefix() {
+        let mut buf = LineBuffer::new(2);
+        buf.push("plain line 1".to_string());
+        buf.push("plain line 2".to_string());
+        buf.push("plain line 3".to_string());
+        let display = buf.display_lines();
+        assert_eq!(display, &["plain line 2", "plain line 3"]);
+    }
+
+    #[test]
+    fn color_from_evicted_line_carries_forward() {
+        let mut buf = LineBuffer::new(1);
+        buf.push("\x1B[31mred text".to_string());
+        buf.push("still red".to_string());
+        let display = buf.display_lines();
+        assert_eq!(display, &["\x1B[31mstill red"]);
+    }
+
+    #[test]
+    fn reset_in_evicted_line_clears_state() {
+        let mut buf = LineBuffer::new(1);
+        buf.push("\x1B[31mred\x1B[0m".to_string());
+        buf.push("should be plain".to_string());
+        let display = buf.display_lines();
+        assert_eq!(display, &["should be plain"]);
+    }
+
+    #[test]
+    fn bold_carries_forward() {
+        let mut buf = LineBuffer::new(1);
+        buf.push("\x1B[1mbold text".to_string());
+        buf.push("still bold".to_string());
+        let display = buf.display_lines();
+        assert_eq!(display, &["\x1B[1mstill bold"]);
+    }
+
+    #[test]
+    fn multiple_attributes_carry_forward() {
+        let mut buf = LineBuffer::new(1);
+        buf.push("\x1B[1;31mbold red".to_string());
+        buf.push("still bold red".to_string());
+        let display = buf.display_lines();
+        let display_line = &display[0];
+        assert!(display_line.contains("\x1B["));
+        assert!(display_line.contains("1"));
+        assert!(display_line.contains("31"));
+        assert!(display_line.ends_with("still bold red"));
+    }
+
+    #[test]
+    fn color_within_buffer_no_prefix() {
+        let mut buf = LineBuffer::new(3);
+        buf.push("plain".to_string());
+        buf.push("\x1B[32mgreen".to_string());
+        let display = buf.display_lines();
+        assert_eq!(display, &["plain", "\x1B[32mgreen"]);
+    }
+
+    #[test]
+    fn bg_color_carries_forward() {
+        let mut buf = LineBuffer::new(1);
+        buf.push("\x1B[44mblue bg".to_string());
+        buf.push("still blue bg".to_string());
+        let display = buf.display_lines();
+        assert_eq!(display, &["\x1B[44mstill blue bg"]);
+    }
+
+    #[test]
+    fn palette_color_carries_forward() {
+        let mut buf = LineBuffer::new(1);
+        buf.push("\x1B[38;5;208morange".to_string());
+        buf.push("still orange".to_string());
+        let display = buf.display_lines();
+        let line = &display[0];
+        assert!(line.starts_with("\x1B["));
+        assert!(line.ends_with("still orange"));
+    }
+
+    #[test]
+    fn display_lines_only_prefixes_first_line() {
+        let mut buf = LineBuffer::new(3);
+        buf.push("\x1B[31mred".to_string());
+        buf.push("line 2".to_string());
+        buf.push("line 3".to_string());
+        buf.push("line 4".to_string());
+        let display = buf.display_lines();
+        assert!(display[0].starts_with("\x1B[31m"));
+        assert_eq!(display[1], "line 3");
+        assert_eq!(display[2], "line 4");
+    }
+
+    #[test]
+    fn update_ansi_state_basic_fg() {
+        let mut state = AnsiState::default();
+        update_ansi_state(&mut state, "\x1B[31mhello");
+        assert_eq!(state.fg, Some(Color::Basic(31)));
+    }
+
+    #[test]
+    fn update_ansi_state_reset() {
+        let mut state = AnsiState::default();
+        update_ansi_state(&mut state, "\x1B[31mhello");
+        update_ansi_state(&mut state, "\x1B[0mworld");
+        assert!(state.is_empty());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,10 +101,10 @@ impl AnsiState {
         if self.hidden { codes.push("8".into()); }
         if self.strikethrough { codes.push("9".into()); }
         if let Some(ref c) = self.fg {
-            Self::color_to_codes(c, &mut codes);
+            Self::color_to_codes(c, 38, &mut codes);
         }
         if let Some(ref c) = self.bg {
-            Self::color_to_codes(c, &mut codes);
+            Self::color_to_codes(c, 48, &mut codes);
         }
         if codes.is_empty() {
             String::new()
@@ -115,19 +115,11 @@ impl AnsiState {
         }
     }
 
-    fn color_to_codes(color: &Color, codes: &mut Vec<String>) {
+    fn color_to_codes(color: &Color, extended_prefix: u8, codes: &mut Vec<String>) {
         match color {
             Color::Basic(n) => codes.push(n.to_string()),
-            Color::Palette(n) => {
-                // Determine if fg (38) or bg (48) from the original code context
-                // Basic codes 30-37/90-97 are fg, 40-47/100-107 are bg
-                // For palette, we need to check if this is stored as fg or bg
-                // This is handled by the caller context, so we just emit the number
-                codes.push(format!("5;{n}"));
-            }
-            Color::Rgb(r, g, b) => {
-                codes.push(format!("2;{r};{g};{b}"));
-            }
+            Color::Palette(n) => codes.push(format!("{extended_prefix};5;{n}")),
+            Color::Rgb(r, g, b) => codes.push(format!("{extended_prefix};2;{r};{g};{b}")),
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,33 +1,5 @@
 use std::io::{self, BufRead, stdout, Write};
-
-struct LineBuffer {
-    lines: Vec<String>,
-    capacity: usize,
-}
-
-impl LineBuffer {
-    fn new(capacity: usize) -> Self {
-        Self {
-            lines: Vec::new(),
-            capacity,
-        }
-    }
-
-    fn push(&mut self, line: String) {
-        self.lines.push(line);
-        if self.lines.len() > self.capacity {
-            self.lines.remove(0);
-        }
-    }
-
-    fn len(&self) -> usize {
-        self.lines.len()
-    }
-
-    fn lines(&self) -> &[String] {
-        &self.lines
-    }
-}
+use ttail::LineBuffer;
 
 fn clear_lines(num_lines: usize) {
     for _ in 0..num_lines {
@@ -51,68 +23,9 @@ fn main() {
             clear_lines(buf.len());
         }
         buf.push(line.trim().to_string());
-        for l in buf.lines() {
+        for l in buf.display_lines() {
             println!("{}", l);
         }
         first = false;
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn buffer_stays_within_capacity() {
-        let mut buf = LineBuffer::new(3);
-        for i in 0..5 {
-            buf.push(format!("line {i}"));
-        }
-        assert_eq!(buf.len(), 3);
-        assert_eq!(buf.lines(), &["line 2", "line 3", "line 4"]);
-    }
-
-    #[test]
-    fn buffer_under_capacity() {
-        let mut buf = LineBuffer::new(10);
-        buf.push("a".to_string());
-        buf.push("b".to_string());
-        assert_eq!(buf.len(), 2);
-        assert_eq!(buf.lines(), &["a", "b"]);
-    }
-
-    #[test]
-    fn buffer_exact_capacity() {
-        let mut buf = LineBuffer::new(3);
-        buf.push("a".to_string());
-        buf.push("b".to_string());
-        buf.push("c".to_string());
-        assert_eq!(buf.len(), 3);
-        assert_eq!(buf.lines(), &["a", "b", "c"]);
-    }
-
-    #[test]
-    fn buffer_drops_oldest() {
-        let mut buf = LineBuffer::new(2);
-        buf.push("first".to_string());
-        buf.push("second".to_string());
-        buf.push("third".to_string());
-        assert_eq!(buf.lines(), &["second", "third"]);
-    }
-
-    #[test]
-    fn buffer_capacity_one() {
-        let mut buf = LineBuffer::new(1);
-        buf.push("a".to_string());
-        buf.push("b".to_string());
-        assert_eq!(buf.len(), 1);
-        assert_eq!(buf.lines(), &["b"]);
-    }
-
-    #[test]
-    fn empty_buffer() {
-        let buf = LineBuffer::new(10);
-        assert_eq!(buf.len(), 0);
-        assert_eq!(buf.lines(), &[] as &[String]);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use std::io::{self, BufRead, stdout, Write};
 use ttail::LineBuffer;
 
 fn clear_lines(num_lines: usize) {
+    print!("\x1B[0m");
     for _ in 0..num_lines {
         print!("\x1B[1A");
         print!("\x1B[2K");


### PR DESCRIPTION
## Summary
- Track ANSI SGR state (colors, bold, etc.) across evicted lines so colors are preserved even when the originating line scrolls out of the buffer
- Supports basic colors, 256-color palette, and RGB truecolor
- Extract `LineBuffer` and ANSI parsing into `src/lib.rs` for testability
- Add 17 unit tests (6 buffer + 11 ANSI)
- Add performance benchmark suite (`cargo bench` / `scripts/dev/bench.sh`) — not part of CI test gate
- Switch internal buffer from `Vec` to `VecDeque` for O(1) eviction
- Fix background color bleed when clearing lines (reset ANSI before `\x1B[2K`)
- Fix extended color output missing `38;`/`48;` prefix for palette and RGB
- Add colored log test script for visual ANSI verification
- Add `/version-bump` skill for semver version management
- Consolidate publish workflow into `rust.yml` as a `needs: build` job (visible on commits, only runs on main)
- Bump version to 0.2.0
- Update README with install/usage/development instructions

## Test plan
- [x] `cargo test` — 17/17 pass
- [x] `cargo bench` — all benchmarks run
- [x] `./scripts/dev/gen_colored_logs.sh | cargo run` — colors preserved correctly
- [ ] CI passes
- [ ] Publish job visible as commit check after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)