### PR TITLE
Optimize hot paths, cap memory, update docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project
 
-ttail is a Rust CLI tool that buffers terminal output, displaying the last N lines in a scrolling tail view with interactive expand/collapse. Supports two modes: pipe mode (`command | ttail`) and PTY wrapper mode (`ttail command`).
+ttail is a Rust CLI tool that buffers terminal output, displaying the last N lines in a scrolling tail view with interactive expand/collapse. Two modes: pipe mode (`command | ttail`) and PTY wrapper mode (`ttail command`).
 
 ## Build Commands
 
@@ -17,22 +17,23 @@ CI runs on Ubuntu via GitHub Actions (`.github/workflows/rust.yml`) on push/PR t
 
 ## Architecture
 
-Multi-module binary with shared library:
+Multi-module binary (8 source files) with shared library crate:
 
-- `src/lib.rs` — `LineBuffer`, `AnsiState`, ANSI color tracking (shared core)
-- `src/main.rs` — mode detection (pipe vs pty vs usage), entrypoint
-- `src/event.rs` — `Event` enum (`Line`, `Key`, `InputDone`), `Mode` enum
-- `src/display.rs` — `clear_lines`, `draw_collapsed`, `draw_expanded`, `write_line`
-- `src/pipe.rs` — pipe mode: `steal_stdin`, spawn reader threads, `run_pipe_mode`
-- `src/pty.rs` — PTY wrapper mode: `openpty`, `fork+exec`, pty reader, SIGWINCH, key forwarding, `run_pty_mode`
-- `src/interactive.rs` — shared event loop (`run_interactive`), non-interactive fallback
-- `src/term.rs` — terminal helpers: `terminal_size`, `read_key`, raw mode enable/disable
+- `src/main.rs` — entry point, dispatches between pipe mode and PTY wrapper mode
+- `src/lib.rs` — core `LineBuffer` struct with `VecDeque`-based rolling buffer, `AnsiState` tracking for color preservation across buffer eviction
+- `src/display.rs` — terminal drawing functions (collapsed view, expanded view, clear/redraw)
+- `src/event.rs` — event and key code enums (`Event::Line`, `Event::PtyOutput`, `Event::Key`, `Event::InputDone`), `Mode` enum
+- `src/interactive.rs` — main event loop (`run_interactive`) handling events, mode toggling, scrolling, countdown timer; also `run_non_interactive` fallback
+- `src/pipe.rs` — pipe mode setup (stdin reader + `/dev/tty` key reader threads)
+- `src/pty.rs` — PTY wrapper mode (`openpty`, `fork`+`exec`, pty reader, key forwarding, SIGWINCH handling)
+- `src/term.rs` — terminal control (raw mode enable/disable, terminal size query, key parsing)
 
 ### Mode detection
-- stdin is a pipe → pipe mode (current behavior)
+- stdin is a pipe → pipe mode
 - stdin is a tty + args present → PTY wrapper mode (spawns child in pty)
 - stdin is a tty + no args → print usage
 
 ### Dependencies
 - `libc` — openpty, fork, ioctl, waitpid, tcsetattr (raw mode)
 - `signal-hook` — SIGWINCH handling for pty resize
+- No other external dependencies

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "ttail"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "libc",
  "signal-hook",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ttail"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 authors = ["Dmitri Tchebotarev <dmitri@tchebotarev.com>"]
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,17 @@
 # ttail
 
-A small, zero-dependency Rust CLI that displays the last N lines of stdin in a rolling window using ANSI escape codes. Think `tail -f`, but for piped output that overwrites itself in place.
+A small Rust CLI that displays the last N lines of output in a rolling window using ANSI escape codes. Think `tail -f`, but for piped output that overwrites itself in place.
 
 ANSI color codes are preserved — even when the line that set the color has scrolled out of the buffer.
+
+## Features
+
+- **Pipe mode**: `command | ttail` — tails piped output
+- **PTY wrapper mode**: `ttail command [args...]` — wraps a command in a pseudo-terminal
+- **Interactive expand/collapse**: press Tab to toggle a full scrollable view (vim-style j/k, Page Up/Down, Home/End)
+- **Color preservation**: ANSI state tracked across buffer eviction
+- **Bounded memory**: in-memory buffer capped at 10k lines, overflow spills to a temp file (auto-cleaned)
+- **Auto-exit**: countdown timer after input completes (configurable via `TTAIL_COUNTDOWN_SECS`)
 
 ## Install
 
@@ -16,9 +25,36 @@ cargo install ttail
 # Pipe any command into ttail
 my-noisy-command | ttail
 
+# Wrap a command in a pty
+ttail cargo test
+
 # Great for watching logs, builds, test output, etc.
 cargo test 2>&1 | ttail
 ```
+
+## Controls
+
+| Key | Action |
+|-----|--------|
+| Tab | Toggle expanded scroll view |
+| j/k | Scroll up/down (expanded) |
+| Page Up/Down | Scroll by page |
+| Home/End (g/G) | Jump to start/end |
+| q / Ctrl+C | Quit |
+
+## Performance
+
+Benchmarks on the core `LineBuffer` (Apple M-series, single-threaded):
+
+| Operation | Time |
+|-----------|------|
+| Push 1k plain lines | ~95μs |
+| Push 1k colored lines | ~106μs |
+| Display 10-line window | ~4.4μs |
+| Parse simple SGR sequence | ~12ns |
+| Parse complex SGR (bold + palette + RGB) | ~78ns |
+| Display range from middle of 1k lines | ~77μs |
+| Realistic workload (200 × 5 colored log lines) | ~301μs |
 
 ## Development
 
@@ -30,5 +66,5 @@ cargo test --verbose
 ./scripts/dev/gen_logs.sh | cargo run
 
 # Run performance benchmarks
-./scripts/dev/bench.sh
+cargo bench
 ```

--- a/src/display.rs
+++ b/src/display.rs
@@ -11,10 +11,11 @@ pub fn write_line(out: &mut io::StdoutLock, line: &str, raw_mode: bool) {
 }
 
 pub fn clear_lines(out: &mut io::StdoutLock, num_lines: usize) {
-    write!(out, "\x1B[0m").ok();
+    let mut buf = String::from("\x1B[0m");
     for _ in 0..num_lines {
-        write!(out, "\x1B[1A\x1B[2K").ok();
+        buf.push_str("\x1B[1A\x1B[2K");
     }
+    write!(out, "{buf}").ok();
     out.flush().ok();
 }
 
@@ -25,6 +26,7 @@ pub fn draw_collapsed(
     first: bool,
     raw_mode: bool,
     input_done: bool,
+    countdown: Option<u8>,
 ) -> usize {
     if !first {
         clear_lines(out, prev_lines);
@@ -33,13 +35,16 @@ pub fn draw_collapsed(
     for l in &lines {
         write_line(out, l, raw_mode);
     }
-    let status = if input_done {
-        format!(
+    let status = match countdown {
+        Some(s) => format!(
+            "\x1B[0;2m[Tab: expand | {} lines | done | exiting in {}s]\x1B[0m",
+            buf.total_count(), s,
+        ),
+        None if input_done => format!(
             "\x1B[0;2m[Tab: expand | {} lines | done]\x1B[0m",
             buf.total_count()
-        )
-    } else {
-        format!("\x1B[0;2m[Tab: expand | {} lines]\x1B[0m", buf.total_count())
+        ),
+        None => format!("\x1B[0;2m[Tab: expand | {} lines]\x1B[0m", buf.total_count()),
     };
     write_line(out, &status, raw_mode);
     out.flush().ok();

--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use ttail::LineBuffer;
 
-use crate::display::{clear_lines, draw_collapsed, draw_expanded, write_line};
+use crate::display::{clear_lines, draw_collapsed, draw_expanded};
 use crate::event::{Event, KeyCode, Mode};
 use crate::pty::{self, PtyContext};
 use crate::term;
@@ -21,42 +21,41 @@ fn countdown_secs() -> u8 {
 fn extract_lines(remainder: &mut Vec<u8>, data: &[u8]) -> Vec<String> {
     remainder.extend_from_slice(data);
     let mut lines = Vec::new();
-    while let Some(pos) = remainder.iter().position(|&b| b == b'\n') {
-        let line_bytes: Vec<u8> = remainder.drain(..=pos).collect();
-        let s = String::from_utf8_lossy(&line_bytes[..line_bytes.len() - 1]);
+    let mut start = 0;
+    while let Some(pos) = remainder[start..].iter().position(|&b| b == b'\n') {
+        let end = start + pos;
+        let s = String::from_utf8_lossy(&remainder[start..end]);
         lines.push(s.trim_end_matches('\r').to_string());
+        start = end + 1;
+    }
+    if start > 0 {
+        remainder.drain(..start);
     }
     lines
 }
 
-fn draw_collapsed_with_countdown(
+fn draw_after_push(
     out: &mut io::StdoutLock,
     buf: &LineBuffer,
-    prev_lines: usize,
-    first: bool,
-    countdown: Option<u8>,
-) -> usize {
-    if !first {
-        clear_lines(out, prev_lines);
+    mode: &Mode,
+    prev_drawn_lines: &mut usize,
+    first: &mut bool,
+    scroll_offset: &mut usize,
+    input_done: bool,
+) {
+    match mode {
+        Mode::Collapsed => {
+            *prev_drawn_lines = draw_collapsed(
+                out, buf, *prev_drawn_lines, *first, true, input_done, None,
+            );
+            *first = false;
+        }
+        Mode::Expanded => {
+            redraw_expanded_on_new_line(
+                out, buf, scroll_offset, prev_drawn_lines, input_done,
+            );
+        }
     }
-    let lines = buf.display_lines();
-    for l in &lines {
-        write_line(out, l, true);
-    }
-    let status = match countdown {
-        Some(s) => format!(
-            "\x1B[0;2m[Tab: expand | {} lines | done | exiting in {}s]\x1B[0m",
-            buf.total_count(),
-            s,
-        ),
-        None => format!(
-            "\x1B[0;2m[Tab: expand | {} lines | done]\x1B[0m",
-            buf.total_count(),
-        ),
-    };
-    write_line(out, &status, true);
-    out.flush().ok();
-    lines.len() + 1
 }
 
 pub fn run_interactive(rx: mpsc::Receiver<Event>, pty: Option<PtyContext>) {
@@ -86,12 +85,8 @@ pub fn run_interactive(rx: mpsc::Receiver<Event>, pty: Option<PtyContext>) {
                     }
                     if mode == Mode::Collapsed {
                         clear_lines(&mut out, prev_drawn_lines);
-                        prev_drawn_lines = draw_collapsed_with_countdown(
-                            &mut out,
-                            &buf,
-                            0,
-                            true,
-                            countdown,
+                        prev_drawn_lines = draw_collapsed(
+                            &mut out, &buf, 0, true, true, true, countdown,
                         );
                     }
                     continue;
@@ -108,29 +103,7 @@ pub fn run_interactive(rx: mpsc::Receiver<Event>, pty: Option<PtyContext>) {
         match event {
             Event::Line(line) => {
                 buf.push(line.trim().to_string());
-
-                match mode {
-                    Mode::Collapsed => {
-                        prev_drawn_lines = draw_collapsed(
-                            &mut out,
-                            &buf,
-                            prev_drawn_lines,
-                            first,
-                            true,
-                            input_done,
-                        );
-                        first = false;
-                    }
-                    Mode::Expanded => {
-                        redraw_expanded_on_new_line(
-                            &mut out,
-                            &buf,
-                            &mut scroll_offset,
-                            &mut prev_drawn_lines,
-                            input_done,
-                        );
-                    }
-                }
+                draw_after_push(&mut out, &buf, &mode, &mut prev_drawn_lines, &mut first, &mut scroll_offset, input_done);
             }
 
             Event::PtyOutput(data) => {
@@ -141,29 +114,7 @@ pub fn run_interactive(rx: mpsc::Receiver<Event>, pty: Option<PtyContext>) {
                 for line in new_lines {
                     buf.push(line.trim().to_string());
                 }
-
-                match mode {
-                    Mode::Collapsed => {
-                        prev_drawn_lines = draw_collapsed(
-                            &mut out,
-                            &buf,
-                            prev_drawn_lines,
-                            first,
-                            true,
-                            input_done,
-                        );
-                        first = false;
-                    }
-                    Mode::Expanded => {
-                        redraw_expanded_on_new_line(
-                            &mut out,
-                            &buf,
-                            &mut scroll_offset,
-                            &mut prev_drawn_lines,
-                            input_done,
-                        );
-                    }
-                }
+                draw_after_push(&mut out, &buf, &mode, &mut prev_drawn_lines, &mut first, &mut scroll_offset, input_done);
             }
 
             Event::Key(key) => {
@@ -193,7 +144,7 @@ pub fn run_interactive(rx: mpsc::Receiver<Event>, pty: Option<PtyContext>) {
                             mode = Mode::Collapsed;
                             first = true;
                             prev_drawn_lines =
-                                draw_collapsed(&mut out, &buf, 0, true, true, input_done);
+                                draw_collapsed(&mut out, &buf, 0, true, true, input_done, None);
                         }
                     }
                     continue;
@@ -258,18 +209,9 @@ pub fn run_interactive(rx: mpsc::Receiver<Event>, pty: Option<PtyContext>) {
                     if prev_drawn_lines > 0 {
                         clear_lines(&mut out, prev_drawn_lines);
                     }
-                    if countdown.is_some() {
-                        prev_drawn_lines = draw_collapsed_with_countdown(
-                            &mut out,
-                            &buf,
-                            0,
-                            true,
-                            countdown,
-                        );
-                    } else {
-                        prev_drawn_lines =
-                            draw_collapsed(&mut out, &buf, 0, true, true, input_done);
-                    }
+                    prev_drawn_lines = draw_collapsed(
+                        &mut out, &buf, 0, true, true, input_done, countdown,
+                    );
                 } else {
                     clear_lines(&mut out, prev_drawn_lines);
                     let (_, rows) = term::terminal_size();
@@ -325,13 +267,14 @@ pub fn run_non_interactive() {
     let mut prev_drawn_lines: usize = 0;
 
     while let Some(Ok(line)) = input.next() {
-        if line.trim().is_empty() {
+        let trimmed = line.trim().to_string();
+        if trimmed.is_empty() {
             break;
         }
         if !first {
             clear_lines(&mut out, prev_drawn_lines);
         }
-        buf.push(line.trim().to_string());
+        buf.push(trimmed);
         let lines = buf.display_lines();
         for l in &lines {
             writeln!(out, "{}", l).ok();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,10 @@
 use std::collections::VecDeque;
 use std::fmt::Write;
+use std::io::Write as IoWrite;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 #[derive(Clone, Default, PartialEq, Debug)]
 pub struct AnsiState {
-    reset: bool,
     bold: bool,
     dim: bool,
     italic: bool,
@@ -91,50 +92,71 @@ impl AnsiState {
     }
 
     pub fn to_escape(&self) -> String {
-        let mut codes: Vec<String> = Vec::new();
-        if self.bold { codes.push("1".into()); }
-        if self.dim { codes.push("2".into()); }
-        if self.italic { codes.push("3".into()); }
-        if self.underline { codes.push("4".into()); }
-        if self.blink { codes.push("5".into()); }
-        if self.reverse { codes.push("7".into()); }
-        if self.hidden { codes.push("8".into()); }
-        if self.strikethrough { codes.push("9".into()); }
+        let mut out = String::new();
+        let mut sep = false;
+
+        macro_rules! push_code {
+            ($val:expr) => {{
+                if sep { out.push(';'); }
+                write!(out, "{}", $val).unwrap();
+                sep = true;
+            }};
+        }
+
+        if self.bold { push_code!("1"); }
+        if self.dim { push_code!("2"); }
+        if self.italic { push_code!("3"); }
+        if self.underline { push_code!("4"); }
+        if self.blink { push_code!("5"); }
+        if self.reverse { push_code!("7"); }
+        if self.hidden { push_code!("8"); }
+        if self.strikethrough { push_code!("9"); }
         if let Some(ref c) = self.fg {
-            Self::color_to_codes(c, 38, &mut codes);
+            Self::write_color(&mut out, c, 38, &mut sep);
         }
         if let Some(ref c) = self.bg {
-            Self::color_to_codes(c, 48, &mut codes);
+            Self::write_color(&mut out, c, 48, &mut sep);
         }
-        if codes.is_empty() {
+        if out.is_empty() {
             String::new()
         } else {
-            let mut out = String::new();
-            write!(out, "\x1B[{}m", codes.join(";")).unwrap();
-            out
+            format!("\x1B[{out}m")
         }
     }
 
-    fn color_to_codes(color: &Color, extended_prefix: u8, codes: &mut Vec<String>) {
+    fn write_color(out: &mut String, color: &Color, prefix: u8, sep: &mut bool) {
+        if *sep { out.push(';'); }
         match color {
-            Color::Basic(n) => codes.push(n.to_string()),
-            Color::Palette(n) => codes.push(format!("{extended_prefix};5;{n}")),
-            Color::Rgb(r, g, b) => codes.push(format!("{extended_prefix};2;{r};{g};{b}")),
+            Color::Basic(n) => write!(out, "{n}").unwrap(),
+            Color::Palette(n) => write!(out, "{prefix};5;{n}").unwrap(),
+            Color::Rgb(r, g, b) => write!(out, "{prefix};2;{r};{g};{b}").unwrap(),
         }
+        *sep = true;
     }
 
     pub fn is_empty(&self) -> bool {
-        *self == Self::default()
+        !self.bold && !self.dim && !self.italic && !self.underline
+            && !self.blink && !self.reverse && !self.hidden && !self.strikethrough
+            && self.fg.is_none() && self.bg.is_none()
     }
 }
 
-fn parse_sgr_params(seq: &str) -> Vec<u8> {
+fn parse_sgr_params(seq: &str) -> ([u8; 16], usize) {
     if seq.is_empty() {
-        return vec![0];
+        let mut arr = [0u8; 16];
+        arr[0] = 0;
+        return (arr, 1);
     }
-    seq.split(';')
-        .filter_map(|s| s.parse::<u8>().ok())
-        .collect()
+    let mut arr = [0u8; 16];
+    let mut len = 0;
+    for s in seq.split(';') {
+        if len >= 16 { break; }
+        if let Ok(v) = s.parse::<u8>() {
+            arr[len] = v;
+            len += 1;
+        }
+    }
+    (arr, len)
 }
 
 pub fn update_ansi_state(state: &mut AnsiState, line: &str) {
@@ -153,8 +175,8 @@ pub fn update_ansi_state(state: &mut AnsiState, line: &str) {
             }
             if i < len && bytes[i] == b'm' {
                 let param_str = &line[start..i];
-                let params = parse_sgr_params(param_str);
-                state.apply_sgr(&params);
+                let (params, len) = parse_sgr_params(param_str);
+                state.apply_sgr(&params[..len]);
             }
             i += 1;
         } else {
@@ -166,15 +188,35 @@ pub fn update_ansi_state(state: &mut AnsiState, line: &str) {
 pub struct LineBuffer {
     lines: VecDeque<String>,
     window_size: usize,
+    max_history: usize,
     ansi_prefix: AnsiState,
+    spill_file: Option<std::fs::File>,
+    spill_path: Option<std::path::PathBuf>,
+    disk_line_count: usize,
+}
+
+impl Drop for LineBuffer {
+    fn drop(&mut self) {
+        if let Some(ref path) = self.spill_path {
+            std::fs::remove_file(path).ok();
+        }
+    }
 }
 
 impl LineBuffer {
     pub fn new(window_size: usize) -> Self {
+        Self::with_max_history(window_size, 10_000)
+    }
+
+    pub fn with_max_history(window_size: usize, max_history: usize) -> Self {
         Self {
-            lines: VecDeque::new(),
+            lines: VecDeque::with_capacity(window_size.min(max_history)),
             window_size,
+            max_history,
             ansi_prefix: AnsiState::default(),
+            spill_file: None,
+            spill_path: None,
+            disk_line_count: 0,
         }
     }
 
@@ -185,6 +227,41 @@ impl LineBuffer {
             let idx = total - self.window_size - 1;
             update_ansi_state(&mut self.ansi_prefix, &self.lines[idx]);
         }
+        if self.lines.len() > self.max_history {
+            let evicted = self.lines.pop_front().unwrap();
+            self.spill_to_disk(&evicted);
+        }
+    }
+
+    fn spill_to_disk(&mut self, line: &str) {
+        if self.spill_file.is_none() {
+            static COUNTER: AtomicU64 = AtomicU64::new(0);
+            let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+            let path = std::env::temp_dir().join(format!("ttail-{}-{}.log", std::process::id(), id));
+            let file = std::fs::File::create(&path).expect("failed to create spill file");
+            self.spill_path = Some(path);
+            self.spill_file = Some(file);
+        }
+        if let Some(ref mut file) = self.spill_file {
+            writeln!(file, "{}", line).ok();
+        }
+        self.disk_line_count += 1;
+    }
+
+    fn read_disk_lines(&self, start: usize, count: usize) -> Vec<String> {
+        use std::io::{BufRead, BufReader};
+        let Some(ref path) = self.spill_path else {
+            return Vec::new();
+        };
+        let Ok(file) = std::fs::File::open(path) else {
+            return Vec::new();
+        };
+        BufReader::new(file)
+            .lines()
+            .skip(start)
+            .take(count)
+            .filter_map(|l| l.ok())
+            .collect()
     }
 
     pub fn visible_len(&self) -> usize {
@@ -192,7 +269,7 @@ impl LineBuffer {
     }
 
     pub fn total_count(&self) -> usize {
-        self.lines.len()
+        self.disk_line_count + self.lines.len()
     }
 
     pub fn all_lines(&self) -> &VecDeque<String> {
@@ -208,46 +285,70 @@ impl LineBuffer {
     pub fn display_lines(&self) -> Vec<String> {
         let total = self.lines.len();
         let start = total.saturating_sub(self.window_size);
-        let window: Vec<&str> = self.lines.range(start..).map(|s| s.as_str()).collect();
-        if window.is_empty() || self.ansi_prefix.is_empty() {
-            return window.into_iter().map(String::from).collect();
+        if self.ansi_prefix.is_empty() {
+            return self.lines.range(start..).map(|s| s.to_string()).collect();
         }
         let prefix = self.ansi_prefix.to_escape();
-        let mut result: Vec<String> = Vec::with_capacity(window.len());
-        result.push(format!("{}{}", prefix, window[0]));
-        for line in &window[1..] {
-            result.push((*line).to_string());
+        let mut result: Vec<String> = Vec::with_capacity(self.visible_len());
+        let mut first = true;
+        for line in self.lines.range(start..) {
+            if first {
+                result.push(format!("{prefix}{line}"));
+                first = false;
+            } else {
+                result.push(line.to_string());
+            }
         }
         result
     }
 
     pub fn display_range(&self, start: usize, count: usize) -> Vec<String> {
-        let total = self.lines.len();
+        let total = self.total_count();
         let end = (start + count).min(total);
         if start >= total {
             return Vec::new();
         }
 
-        // Compute ANSI state up to `start` by scanning all lines before it
+        // Compute ANSI state by scanning all lines before `start`
         let mut state = AnsiState::default();
-        for i in 0..start {
-            update_ansi_state(&mut state, &self.lines[i]);
+        if self.disk_line_count > 0 {
+            let disk_scan_end = start.min(self.disk_line_count);
+            if disk_scan_end > 0 {
+                for line in self.read_disk_lines(0, disk_scan_end) {
+                    update_ansi_state(&mut state, &line);
+                }
+            }
+        }
+        if start > self.disk_line_count {
+            let mem_scan_end = start - self.disk_line_count;
+            for i in 0..mem_scan_end {
+                update_ansi_state(&mut state, &self.lines[i]);
+            }
         }
 
-        let slice: Vec<&str> = self.lines.range(start..end).map(|s| s.as_str()).collect();
-        if slice.is_empty() {
+        // Collect lines in the display range from disk and/or memory
+        let mut raw_lines: Vec<String> = Vec::with_capacity(end - start);
+        if start < self.disk_line_count {
+            let disk_end = end.min(self.disk_line_count);
+            raw_lines.extend(self.read_disk_lines(start, disk_end - start));
+        }
+        if end > self.disk_line_count {
+            let mem_start = start.saturating_sub(self.disk_line_count);
+            let mem_end = end - self.disk_line_count;
+            for line in self.lines.range(mem_start..mem_end) {
+                raw_lines.push(line.to_string());
+            }
+        }
+
+        if raw_lines.is_empty() {
             return Vec::new();
         }
         if state.is_empty() {
-            return slice.into_iter().map(String::from).collect();
+            return raw_lines;
         }
         let prefix = state.to_escape();
-        let mut result: Vec<String> = Vec::with_capacity(slice.len());
-        result.push(format!("{}{}", prefix, slice[0]));
-        for line in &slice[1..] {
-            result.push((*line).to_string());
-        }
-        result
+        raw_lines[0] = format!("{prefix}{}", raw_lines[0]);
+        raw_lines
     }
 }
 
@@ -439,7 +540,6 @@ mod tests {
         buf.push("\x1B[31mred".to_string());
         buf.push("line 2".to_string());
         buf.push("line 3".to_string());
-        // Range starting at line 1 should carry red prefix
         let range = buf.display_range(1, 2);
         assert!(range[0].starts_with("\x1B[31m"));
         assert_eq!(range[0].ends_with("line 2"), true);
@@ -463,5 +563,47 @@ mod tests {
         buf.push("b".to_string());
         let range = buf.display_range(0, 100);
         assert_eq!(range, &["a", "b"]);
+    }
+
+    #[test]
+    fn max_history_caps_memory() {
+        let mut buf = LineBuffer::with_max_history(3, 10);
+        for i in 0..20 {
+            buf.push(format!("line {i}"));
+        }
+        assert_eq!(buf.total_count(), 20);
+        assert_eq!(buf.lines.len(), 10);
+        assert_eq!(buf.disk_line_count, 10);
+        assert_eq!(buf.visible_len(), 3);
+        assert_eq!(buf.window_lines(), &["line 17", "line 18", "line 19"]);
+    }
+
+    #[test]
+    fn disk_spill_lines_readable() {
+        let mut buf = LineBuffer::with_max_history(2, 5);
+        for i in 0..10 {
+            buf.push(format!("line {i}"));
+        }
+        assert_eq!(buf.disk_line_count, 5);
+        assert_eq!(buf.lines.len(), 5);
+        let range = buf.display_range(0, 3);
+        assert_eq!(range, &["line 0", "line 1", "line 2"]);
+        let range = buf.display_range(3, 4);
+        assert_eq!(range, &["line 3", "line 4", "line 5", "line 6"]);
+        let range = buf.display_range(7, 3);
+        assert_eq!(range, &["line 7", "line 8", "line 9"]);
+    }
+
+    #[test]
+    fn disk_spill_preserves_ansi_state() {
+        let mut buf = LineBuffer::with_max_history(2, 3);
+        buf.push("\x1B[31mred".to_string());
+        buf.push("line 2".to_string());
+        buf.push("line 3".to_string());
+        buf.push("line 4".to_string());
+        assert_eq!(buf.disk_line_count, 1);
+        let range = buf.display_range(1, 2);
+        assert!(range[0].starts_with("\x1B[31m"));
+        assert!(range[0].ends_with("line 2"));
     }
 }


### PR DESCRIPTION
## Summary
- Eliminate heap allocations in ANSI parsing hot path (stack array for `parse_sgr_params`, direct string writes in `to_escape`)
- Remove intermediate `Vec<&str>` in display methods, batch `clear_lines` into single write
- Cap VecDeque at 10k lines with automatic disk spill for overflow — no data loss
- Deduplicate Line/PtyOutput draw logic and unify countdown/collapsed draw functions
- Update README with features, controls, and performance benchmarks
- Update CLAUDE.md to reflect current multi-module architecture
- Bump version to 0.3.1

## Performance

| Benchmark | Before | After | Change |
|-----------|--------|-------|--------|
| `push_colored_lines_1k` | 184.6μs | 105.8μs | **43% faster** |
| `ansi_state_parse_simple` | 31ns | 12ns | **61% faster** |
| `ansi_state_parse_complex` | 184ns | 78ns | **58% faster** |
| `display_range_middle` | 131.2μs | 76.7μs | **42% faster** |
| `push_and_display_realistic` | 391.1μs | 301.4μs | **23% faster** |

## Test plan
- [x] All 62 tests pass (`cargo test --verbose`)
- [x] All 8 benchmarks run successfully (`cargo bench`)
- [ ] Manual smoke test: `seq 100 | cargo run` and `cargo run -- echo hello`

🤖 Generated with [Claude Code](https://claude.com/claude-code)