### PR TITLE
Add -h/--help flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "ttail"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "libc",
  "signal-hook",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ttail"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2024"
 authors = ["Dmitri Tchebotarev <dmitri@tchebotarev.com>"]
 license = "MIT"

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,9 +5,25 @@ mod pipe;
 mod pty;
 mod term;
 
+fn print_usage() {
+    println!("ttail — tail with scroll\n");
+    println!("Usage:");
+    println!("  ttail <command> [args...]   wrap a command in a pty");
+    println!("  command | ttail             tail piped output\n");
+    println!("Controls:");
+    println!("  Tab      toggle expanded scroll view");
+    println!("  j/k      scroll up/down (expanded)");
+    println!("  q        quit");
+}
+
 fn main() {
     let args: Vec<String> = std::env::args().skip(1).collect();
     let is_stdin_pipe = unsafe { libc::isatty(0) == 0 };
+
+    if args.first().map(|a| a == "-h" || a == "--help").unwrap_or(false) {
+        print_usage();
+        std::process::exit(0);
+    }
 
     if is_stdin_pipe {
         // Pipe mode: command | ttail
@@ -16,14 +32,7 @@ fn main() {
         // PTY wrapper mode: ttail <command> [args...]
         pty::run_pty_mode(&args[0], &args[1..]);
     } else {
-        println!("ttail — tail with scroll\n");
-        println!("Usage:");
-        println!("  ttail <command> [args...]   wrap a command in a pty");
-        println!("  command | ttail             tail piped output\n");
-        println!("Controls:");
-        println!("  Tab      toggle expanded scroll view");
-        println!("  j/k      scroll up/down (expanded)");
-        println!("  q        quit");
+        print_usage();
         std::process::exit(1);
     }
 }


### PR DESCRIPTION
## Summary
- Add `-h`/`--help` flag support, exiting with code 0 (vs 1 for no-args usage)
- Extract usage text into `print_usage()` to avoid duplication
- Bump version to 0.3.2

## Test plan
- [x] `cargo build` succeeds
- [x] `cargo test` passes (18 tests)
- [ ] `ttail --help` prints usage and exits 0
- [ ] `ttail -h` prints usage and exits 0
- [ ] `ttail` (no args, tty stdin) prints usage and exits 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)