### PR TITLE
Skip crates.io publish if version already exists

### DIFF
--- a/scripts/ci/publish.sh
+++ b/scripts/ci/publish.sh
@@ -1,4 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+VERSION="$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -1)"
+
+# Check if this version is already published
+if cargo search ttail --limit 1 | grep -q "^ttail = \"$VERSION\""; then
+  echo "ttail@$VERSION already published to crates.io, skipping"
+  exit 0
+fi
+
 cargo publish


### PR DESCRIPTION
## Summary
- Check if the current version is already on crates.io before running `cargo publish`
- Exits 0 with a message instead of failing when the version is already published

Fixes the CI failure at https://github.com/DTchebotarev/ttail/actions/runs/23129151523/job/67178758665 where the publish step failed with `crate ttail@0.3.2 already exists on crates.io index`.

## Test plan
- [ ] CI passes (publish step skips gracefully)
- [ ] On a version bump, publish still works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)