### PR TITLE
Use PAT for auto-tag to trigger release workflow

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -7,12 +7,11 @@ on:
 jobs:
   tag:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_PAT }}
       - name: Get version from Cargo.toml
         id: ver
         run: |


### PR DESCRIPTION
## Summary
- Use `RELEASE_PAT` secret instead of default `GITHUB_TOKEN` in the auto-tag workflow
- Tags created by `GITHUB_TOKEN` don't trigger other workflows (GitHub's anti-loop protection), so the release workflow was never firing

## Setup required
Add a `RELEASE_PAT` secret to the repo (Settings > Secrets > Actions) with a PAT that has `contents: write` on this repo. Can be the same PAT as `HOMEBREW_TAP_TOKEN` if it has the right scope.

## Test plan
- [ ] Merge a version bump PR → auto-tag creates tag → release workflow triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)